### PR TITLE
[feature] product internal API (GET /internal/v1/products/{id})

### DIFF
--- a/productservice/src/main/java/com/trustamarket/productservice/presentation/controller/ProductInternalController.java
+++ b/productservice/src/main/java/com/trustamarket/productservice/presentation/controller/ProductInternalController.java
@@ -1,0 +1,28 @@
+package com.trustamarket.productservice.presentation.controller;
+
+import com.trustamarket.productservice.application.ProductQueryService;
+import com.trustamarket.productservice.presentation.dto.response.ProductInfoResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+// 다른 서비스(MSA 내부)가 호출하는 internal API.
+// Gateway 라우팅 대상이 아니라 service-to-service 직접 호출 (Feign).
+// 인증은 common 의 LoginFilter 가 X-User-* 헤더 신뢰 + FeignConfig 가 헤더 자동 전파로 보장.
+@RestController
+@RequestMapping("/internal/v1/products")
+@RequiredArgsConstructor
+public class ProductInternalController {
+
+    private final ProductQueryService productQueryService;
+
+    // 상품 단건 조회 — order-service 가 주문 생성 시 product 검증/snapshot 에 사용
+    @GetMapping("/{productId}")
+    public ProductInfoResponse getProductInfo(@PathVariable UUID productId) {
+        return ProductInfoResponse.from(productQueryService.findById(productId));
+    }
+}

--- a/productservice/src/main/java/com/trustamarket/productservice/presentation/dto/response/ProductInfoResponse.java
+++ b/productservice/src/main/java/com/trustamarket/productservice/presentation/dto/response/ProductInfoResponse.java
@@ -1,0 +1,27 @@
+package com.trustamarket.productservice.presentation.dto.response;
+
+import com.trustamarket.productservice.domain.product.Product;
+import com.trustamarket.productservice.domain.product.ProductStatus;
+
+import java.util.UUID;
+
+// internal API (`GET /internal/v1/products/{id}`) 응답.
+// 다른 서비스(주로 order-service)가 주문 생성 시 product 검증/snapshot 용도로 호출.
+// 외부 노출 ProductResponse 와 다르게 imageUrls / inspectionStatus 등 상세 X — 주문 도메인이 필요한 최소 필드만.
+public record ProductInfoResponse(
+        UUID id,
+        UUID sellerId,
+        String title,
+        Integer price,
+        ProductStatus status
+) {
+    public static ProductInfoResponse from(Product product) {
+        return new ProductInfoResponse(
+                product.getId(),
+                product.getSellerId(),
+                product.getTitle(),
+                product.getPrice(),
+                product.getStatus()
+        );
+    }
+}


### PR DESCRIPTION
## 🌱 설명

타 서비스 (주로 order-service) 가 주문 생성 시 product 검증/snapshot 용도로 호출할 internal API 추가.
Gateway 라우팅 대상 X — service-to-service 직접 호출 (Feign).

## 📌 관련 이슈

이슈 없음

## ✅ 주요 변경 사항

- `ProductInternalController` — `GET /internal/v1/products/{id}`
- `ProductInfoResponse` — id / sellerId / title / price / status 5개 필드만 (외부 노출 `ProductResponse` 보다 가벼움)
- `ProductQueryService.findById()` 그대로 재사용

## 📝 체크리스트

- [x] dev 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

- order-service 가 본 API 호출해서 (1) `status == ON_SALE` 검증 (2) name/price snapshot 으로 사용. 클라이언트가 보낸 가격/이름 변조를 방지.
- 인증은 common 의 `LoginFilter` 가 X-User-* 헤더 신뢰 + `FeignConfig` 가 헤더 자동 전파로 보장.
- 향후 `imageUrl` 등 추가 필드 필요하면 `ProductInfoResponse` 확장 (외부 응답엔 영향 X).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new API endpoint to retrieve product details by ID, returning essential product information including seller details, title, price, and availability status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->