### PR TITLE
product sold-out Kafka consumer + ON_SALE→SOLD_OUT 전이 허용

### DIFF
--- a/productservice/src/main/java/com/trustamarket/productservice/application/ProductCommandService.java
+++ b/productservice/src/main/java/com/trustamarket/productservice/application/ProductCommandService.java
@@ -162,4 +162,18 @@ public class ProductCommandService {
         product.failInspection(inspectorId);
         return productRepository.save(product);
     }
+
+    // 주문 확정 이벤트 (Kafka order.product.sold-out) 수신 시 호출. 시스템 호출이라 sellerId 검증 X.
+    // 멱등성: 이미 SOLD_OUT 인 상품은 no-op (재배달 대비).
+    public void markSoldOutByOrder(UUID productId) {
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new ProductNotFoundException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+        if (product.getStatus() == ProductStatus.SOLD_OUT) {
+            return;
+        }
+        productDomainService.validateStatusTransition(product.getStatus(), ProductStatus.SOLD_OUT);
+        product.markSoldOutByOrder();
+        productRepository.save(product);
+    }
 }

--- a/productservice/src/main/java/com/trustamarket/productservice/application/event/ProductSoldOutListener.java
+++ b/productservice/src/main/java/com/trustamarket/productservice/application/event/ProductSoldOutListener.java
@@ -1,6 +1,8 @@
 package com.trustamarket.productservice.application.event;
 
 import com.trustamarket.productservice.application.ProductCommandService;
+import com.trustamarket.productservice.application.exception.InvalidStatusTransitionException;
+import com.trustamarket.productservice.application.exception.ProductNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -23,10 +25,15 @@ public class ProductSoldOutListener {
                     message.eventId(), message.productId(), message.orderId());
             productCommandService.markSoldOutByOrder(message.productId());
             ack.acknowledge();
+        } catch (ProductNotFoundException | InvalidStatusTransitionException e) {
+            // 비재시도성 비즈니스 실패 — 무한 재배달 방지 위해 ack + skip. (DLT 도입 전 임시)
+            log.warn("[ProductSoldOut] non-retryable, ack and skip — eventId={}, productId={}",
+                    message.eventId(), message.productId(), e);
+            ack.acknowledge();
         } catch (Exception e) {
+            // 통신/일시 오류 — ack 안 함 → 재시도 가능
             log.error("[ProductSoldOut] 처리 실패 — eventId={}, productId={}",
                     message.eventId(), message.productId(), e);
-            // ack 안 함 → 재시도 가능
             throw e;
         }
     }

--- a/productservice/src/main/java/com/trustamarket/productservice/application/event/ProductSoldOutListener.java
+++ b/productservice/src/main/java/com/trustamarket/productservice/application/event/ProductSoldOutListener.java
@@ -1,0 +1,33 @@
+package com.trustamarket.productservice.application.event;
+
+import com.trustamarket.productservice.application.ProductCommandService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+// order.product.sold-out 토픽 consume → product status SOLD_OUT 으로 전이.
+// 멱등성: ProductCommandService.markSoldOutByOrder 가 이미 SOLD_OUT 인 상품은 no-op 처리.
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProductSoldOutListener {
+
+    private final ProductCommandService productCommandService;
+
+    @KafkaListener(topics = "${trusta.messaging.topic.product-sold-out}", groupId = "product-sold-out-group")
+    public void consume(ProductSoldOutMessage message, Acknowledgment ack) {
+        try {
+            log.info("[ProductSoldOut] consume — eventId={}, productId={}, orderId={}",
+                    message.eventId(), message.productId(), message.orderId());
+            productCommandService.markSoldOutByOrder(message.productId());
+            ack.acknowledge();
+        } catch (Exception e) {
+            log.error("[ProductSoldOut] 처리 실패 — eventId={}, productId={}",
+                    message.eventId(), message.productId(), e);
+            // ack 안 함 → 재시도 가능
+            throw e;
+        }
+    }
+}

--- a/productservice/src/main/java/com/trustamarket/productservice/application/event/ProductSoldOutMessage.java
+++ b/productservice/src/main/java/com/trustamarket/productservice/application/event/ProductSoldOutMessage.java
@@ -1,0 +1,12 @@
+package com.trustamarket.productservice.application.event;
+
+import java.time.Instant;
+import java.util.UUID;
+
+// order-service 가 confirm 시 발행하는 이벤트. Kafka topic: order.product.sold-out
+public record ProductSoldOutMessage(
+        UUID eventId,
+        UUID orderId,
+        UUID productId,
+        Instant soldAt
+) {}

--- a/productservice/src/main/java/com/trustamarket/productservice/domain/product/Product.java
+++ b/productservice/src/main/java/com/trustamarket/productservice/domain/product/Product.java
@@ -172,6 +172,12 @@ public class Product {
         this.status = ProductStatus.ON_SALE;
     }
 
+    // 주문 확정 이벤트로 인한 시스템 SOLD_OUT 전환. 사전 ProductDomainService.validateStatusTransition 통과 가정.
+    public void markSoldOutByOrder() {
+        this.status = ProductStatus.SOLD_OUT;
+        onUpdate();
+    }
+
     // 검수 시작 (검수자가 상품 수령 후)
     public void startInspection(UUID inspectorId) {
         if (this.inspectionStatus != InspectionStatus.PENDING) {

--- a/productservice/src/main/java/com/trustamarket/productservice/domain/product/ProductDomainService.java
+++ b/productservice/src/main/java/com/trustamarket/productservice/domain/product/ProductDomainService.java
@@ -26,7 +26,8 @@ public class ProductDomainService {
     public void validateStatusTransition(ProductStatus current, ProductStatus next) {
         boolean valid = switch (current) {
             case PENDING_INSPECTION -> next == ProductStatus.ON_SALE;
-            case ON_SALE            -> next == ProductStatus.RESERVED;
+            case ON_SALE            -> next == ProductStatus.RESERVED
+                                    || next == ProductStatus.SOLD_OUT;
             case RESERVED           -> next == ProductStatus.SOLD_OUT
                                     || next == ProductStatus.ON_SALE;
             case SOLD_OUT           -> false;

--- a/productservice/src/main/java/com/trustamarket/productservice/infrastructure/config/KafkaConfig.java
+++ b/productservice/src/main/java/com/trustamarket/productservice/infrastructure/config/KafkaConfig.java
@@ -5,6 +5,7 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
@@ -14,6 +15,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Configuration
+@EnableKafka
 public class KafkaConfig {
 
     @Value("${spring.kafka.bootstrap-servers}")

--- a/productservice/src/main/resources/application.yaml
+++ b/productservice/src/main/resources/application.yaml
@@ -36,6 +36,17 @@ spring:
 
   kafka:
     bootstrap-servers: localhost:9092
+    listener:
+      ack-mode: manual
+    consumer:
+      group-id: product-sold-out-group
+      auto-offset-reset: earliest
+      enable-auto-commit: false
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.trusted.packages: '*'
+        spring.json.value.default.type: com.trustamarket.productservice.application.event.ProductSoldOutMessage
 
   config:
     import: "optional:configserver:http://localhost:8888"
@@ -48,6 +59,9 @@ spring:
 trusta:
   security:
     trust-gateway-headers: true
+  messaging:
+    topic:
+      product-sold-out: order.product.sold-out
 
 # --- AWS S3 설정 추가 ---
 cloud:

--- a/productservice/src/main/resources/application.yaml
+++ b/productservice/src/main/resources/application.yaml
@@ -45,7 +45,7 @@ spring:
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
       properties:
-        spring.json.trusted.packages: '*'
+        spring.json.trusted.packages: com.trustamarket.productservice.application.event
         spring.json.value.default.type: com.trustamarket.productservice.application.event.ProductSoldOutMessage
 
   config:


### PR DESCRIPTION
## 🌱 설명

order-service 가 구매 확정 시 발행하는 `order.product.sold-out` Kafka 토픽을 컨슘해서 product status 를 SOLD_OUT 으로 전이. 정공 흐름의 마지막 puzzle.

## 📌 관련 이슈

close #

## ✅ 주요 변경 사항

- Kafka consumer 추가:
  - `ProductSoldOutMessage` (record): order 측 페이로드와 동일 (eventId, orderId, productId, soldAt)
  - `ProductSoldOutListener`: `@KafkaListener(topics = "${trusta.messaging.topic.product-sold-out}", groupId = "product-sold-out-group")` — 메시지 수신 → `ProductCommandService.markSoldOutByOrder` 호출. ack 는 manual (수동 커밋)
  - `KafkaConfig` 에 `@EnableKafka` 추가 (이전엔 producer 만 있었음)
  - `application.yaml` 에 consumer config + `trusta.messaging.topic.product-sold-out` 토픽 키 추가
- 도메인 변경:
  - `Product.markSoldOutByOrder()` 추가 — system 호출용 SOLD_OUT 전이 (사전 ProductDomainService.validateStatusTransition 통과 가정)
  - `ProductDomainService.validateStatusTransition` 의 ON_SALE 분기에 SOLD_OUT 허용 한 줄 추가
- application 변경:
  - `ProductCommandService.markSoldOutByOrder(productId)` 추가 — system 호출이라 sellerId 검증 X. 멱등성: 이미 SOLD_OUT 이면 no-op (재배달 대비)

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

- order-service 측 PR (`feature/19-product-soldout-event`) 과 짝. **본 PR 먼저 머지** 권장 — consumer 가 준비된 후 publisher 가 시작해야 첫 메시지 누락 위험 0.
- 정공 흐름은 `ON_SALE → RESERVED → SOLD_OUT` 이지만 order-service 의 주문 확정 흐름이 RESERVED 단계 없이 바로 SOLD_OUT 으로 전이함 → 임시로 ON_SALE → SOLD_OUT 직접 전이 허용. 추후 예약 (RESERVED) 흐름 도입 시 재검토 필요.
- base 브랜치는 `dev` (product-service 컨벤션). order-service 는 `develop` 기준이라 base 다른 점 주의.
- consumer 가 일시 fail 시 manual ack 라 재시도 가능. 영구 실패 처리 (DLQ 등) 는 후속 작업.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Products can now be automatically marked as sold out when orders are confirmed, enabling real-time inventory updates.
  * Introduced a structured sold-out event payload to standardize order-driven updates.

* **Improvements**
  * Consumer processing for sold-out events now acknowledges non-retryable errors and retries transient failures to improve reliability.
  * Kafka consumer tuned for manual acknowledgements and safer JSON deserialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->