### PR TITLE
[fix] S3 이미지 업로드 및 product_id FK 저장 오류 수정

### DIFF
--- a/src/main/java/com/trustamarket/productservice/infrastructure/config/S3Config.java
+++ b/src/main/java/com/trustamarket/productservice/infrastructure/config/S3Config.java
@@ -8,6 +8,9 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import org.springframework.beans.factory.annotation.Value;
+import software.amazon.awssdk.services.s3.S3Configuration;
+
+import java.net.URI;
 
 @Configuration
 public class S3Config {
@@ -21,11 +24,13 @@ public class S3Config {
     @Value("${cloud.aws.region.static}")
     private String region;
 
+    private static final String REGION = "ap-southeast-2";
+
     @Bean
     public S3Client s3Client() {
         return S3Client.builder()
-                .region(Region.of(region))
-                .credentialsProvider(awsCredentialsProvider()) // 분리된 빈 사용
+                .region(Region.of(REGION))
+                .credentialsProvider(awsCredentialsProvider())
                 .build();
     }
 

--- a/src/main/java/com/trustamarket/productservice/infrastructure/config/S3Config.java
+++ b/src/main/java/com/trustamarket/productservice/infrastructure/config/S3Config.java
@@ -1,16 +1,15 @@
 package com.trustamarket.productservice.infrastructure.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.util.StringUtils;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
-import org.springframework.beans.factory.annotation.Value;
-import software.amazon.awssdk.services.s3.S3Configuration;
 
-import java.net.URI;
 
 @Configuration
 public class S3Config {
@@ -24,12 +23,14 @@ public class S3Config {
     @Value("${cloud.aws.region.static}")
     private String region;
 
-    private static final String REGION = "ap-southeast-2";
-
     @Bean
     public S3Client s3Client() {
+        if (!StringUtils.hasText(region)) {
+            throw new IllegalStateException(
+                    "cloud.aws.region.static 설정이 누락되었습니다. S3 리전을 config에 명시해주세요.");
+        }
         return S3Client.builder()
-                .region(Region.of(REGION))
+                .region(Region.of(region))
                 .credentialsProvider(awsCredentialsProvider())
                 .build();
     }

--- a/src/main/java/com/trustamarket/productservice/infrastructure/persistence/entity/ProductImageJpaEntity.java
+++ b/src/main/java/com/trustamarket/productservice/infrastructure/persistence/entity/ProductImageJpaEntity.java
@@ -19,6 +19,10 @@ public class ProductImageJpaEntity {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private UUID id;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private ProductJpaEntity product;
+
     @Column(nullable = false)
     private String imageUrl;
 
@@ -28,11 +32,9 @@ public class ProductImageJpaEntity {
     @Column(nullable = false)
     private boolean isThumbnail;
 
-    // Soft Delete 상태를 DB에 저장하기 위한 컬럼
     @Column(nullable = false)
     private boolean isDeleted = false;
 
-    // 삭제된 시간을 저장하기 위한 컬럼
     private Instant deletedAt;
 
     @Builder
@@ -44,5 +46,9 @@ public class ProductImageJpaEntity {
         this.isThumbnail = isThumbnail;
         this.isDeleted = isDeleted;
         this.deletedAt = deletedAt;
+    }
+    
+    public void assignProduct(ProductJpaEntity product) {
+        this.product = product;
     }
 }

--- a/src/main/java/com/trustamarket/productservice/infrastructure/persistence/entity/ProductImageJpaEntity.java
+++ b/src/main/java/com/trustamarket/productservice/infrastructure/persistence/entity/ProductImageJpaEntity.java
@@ -2,7 +2,6 @@ package com.trustamarket.productservice.infrastructure.persistence.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -38,17 +37,25 @@ public class ProductImageJpaEntity {
 
     private Instant deletedAt;
 
-    @Builder
-    public ProductImageJpaEntity(UUID id, String imageUrl,
-                                 int sortOrder, boolean isThumbnail, boolean isDeleted, Instant deletedAt) {
-        this.id = id;
-        this.imageUrl = imageUrl;
-        this.sortOrder = sortOrder;
-        this.isThumbnail = isThumbnail;
-        this.isDeleted = isDeleted;
-        this.deletedAt = deletedAt;
+    public static ProductImageJpaEntity create(ProductJpaEntity product, UUID id,
+                                               String imageUrl, int sortOrder,
+                                               boolean isThumbnail, boolean isDeleted,
+                                               Instant deletedAt) {
+        if (product == null) {
+            throw new IllegalArgumentException("ProductImageJpaEntity 생성 시 product는 필수입니다.");
+        }
+        ProductImageJpaEntity entity = new ProductImageJpaEntity();
+        entity.product = product;
+        entity.id = id;
+        entity.imageUrl = imageUrl;
+        entity.sortOrder = sortOrder;
+        entity.isThumbnail = isThumbnail;
+        entity.isDeleted = isDeleted;
+        entity.deletedAt = deletedAt;
+        return entity;
     }
 
+    // package-private — 관계 변경 진입점을 ProductJpaEntity.addImage()로 제한
     void assignProduct(ProductJpaEntity product) {
         this.product = product;
     }

--- a/src/main/java/com/trustamarket/productservice/infrastructure/persistence/entity/ProductImageJpaEntity.java
+++ b/src/main/java/com/trustamarket/productservice/infrastructure/persistence/entity/ProductImageJpaEntity.java
@@ -19,6 +19,7 @@ public class ProductImageJpaEntity {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private UUID id;
 
+    // 양방향 관계 — product_id FK를 이 쪽에서 직접 관리
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id", nullable = false)
     private ProductJpaEntity product;
@@ -47,8 +48,8 @@ public class ProductImageJpaEntity {
         this.isDeleted = isDeleted;
         this.deletedAt = deletedAt;
     }
-    
-    public void assignProduct(ProductJpaEntity product) {
+
+    void assignProduct(ProductJpaEntity product) {
         this.product = product;
     }
 }

--- a/src/main/java/com/trustamarket/productservice/infrastructure/persistence/entity/ProductJpaEntity.java
+++ b/src/main/java/com/trustamarket/productservice/infrastructure/persistence/entity/ProductJpaEntity.java
@@ -31,6 +31,9 @@ public class ProductJpaEntity {
     @Column(nullable = false)
     private UUID categoryId;
 
+    @Column
+    private UUID inspectorId;
+
     @Column(nullable = false, length = 100)
     private String title;
 
@@ -40,7 +43,6 @@ public class ProductJpaEntity {
     @Column(nullable = false)
     private Long price;
 
-    // inspection-service가 제안한 가격. PRICE_SUGGESTED 상태일 때만 유효.
     @Column
     private Long suggestedPrice;
 
@@ -55,21 +57,20 @@ public class ProductJpaEntity {
     @Column(nullable = false)
     private InspectionStatus inspectionStatus;
 
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
-    @OrderBy("sortOrder ASC") // ProductImageJpaEntity의 sortOrder 필드 기준 정렬
-    @JoinColumn(name = "product_id")
+    @OneToMany(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("sortOrder ASC")
     private List<ProductImageJpaEntity> images = new ArrayList<>();
 
-    @CreatedDate // 자동 생성일 관리
+    @CreatedDate
     @Column(nullable = false, updatable = false)
     private Instant createdAt;
 
-    @LastModifiedDate // 자동 수정일 관리
+    @LastModifiedDate
     @Column(nullable = false)
     private Instant updatedAt;
 
     @Builder
-    public ProductJpaEntity(UUID id, UUID sellerId, UUID categoryId, String title,
+    public ProductJpaEntity(UUID id, UUID sellerId, UUID categoryId, UUID inspectorId, String title,
                             String description, Long price, Long suggestedPrice, ProductGrade grade,
                             ProductStatus status, InspectionStatus inspectionStatus,
                             List<ProductImageJpaEntity> images,
@@ -77,6 +78,7 @@ public class ProductJpaEntity {
         this.id = id;
         this.sellerId = sellerId;
         this.categoryId = categoryId;
+        this.inspectorId = inspectorId;
         this.title = title;
         this.description = description;
         this.price = price;
@@ -84,8 +86,17 @@ public class ProductJpaEntity {
         this.grade = grade;
         this.status = status;
         this.inspectionStatus = inspectionStatus;
-        this.images = images != null ? images : new ArrayList<>();
+        if (images != null) {
+            images.forEach(img -> img.assignProduct(this));
+            this.images = images;
+        }
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
+    }
+
+    // 이미지 추가 시 양방향 관계 동시 세팅
+    public void addImage(ProductImageJpaEntity image) {
+        image.assignProduct(this);
+        this.images.add(image);
     }
 }

--- a/src/main/java/com/trustamarket/productservice/infrastructure/persistence/entity/ProductJpaEntity.java
+++ b/src/main/java/com/trustamarket/productservice/infrastructure/persistence/entity/ProductJpaEntity.java
@@ -87,14 +87,13 @@ public class ProductJpaEntity {
         this.status = status;
         this.inspectionStatus = inspectionStatus;
         if (images != null) {
-            images.forEach(img -> img.assignProduct(this));
-            this.images = images;
+            this.images = new ArrayList<>(images);
+            this.images.forEach(img -> img.assignProduct(this));
         }
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
 
-    // 이미지 추가 시 양방향 관계 동시 세팅
     public void addImage(ProductImageJpaEntity image) {
         image.assignProduct(this);
         this.images.add(image);

--- a/src/main/java/com/trustamarket/productservice/infrastructure/persistence/mapper/ProductMapper.java
+++ b/src/main/java/com/trustamarket/productservice/infrastructure/persistence/mapper/ProductMapper.java
@@ -24,6 +24,7 @@ public class ProductMapper {
         var builder = ProductJpaEntity.builder()
                 .sellerId(product.getSellerId())
                 .categoryId(product.getCategoryId())
+                .inspectorId(product.getInspectorId())
                 .title(product.getTitle())
                 .description(product.getDescription())
                 .price(product.getPrice())
@@ -31,7 +32,6 @@ public class ProductMapper {
                 .grade(product.getGrade())
                 .status(product.getStatus())
                 .inspectionStatus(product.getInspectionStatus())
-                .images(toImageJpaEntities(product.getImages()))
                 .createdAt(product.getCreatedAt())
                 .updatedAt(product.getUpdatedAt());
 
@@ -39,7 +39,13 @@ public class ProductMapper {
             builder.id(product.getId());
         }
 
-        return builder.build();
+        // ProductJpaEntity를 먼저 build한 뒤 팩토리 메서드에 product를 전달
+        // ProductImageJpaEntity.create()가 product를 필수로 받아 NOT NULL 보장
+        ProductJpaEntity jpaEntity = builder.build();
+        toImageJpaEntities(product.getImages(), jpaEntity)
+                .forEach(jpaEntity::addImage);
+
+        return jpaEntity;
     }
 
     // JpaEntity → Domain
@@ -50,7 +56,7 @@ public class ProductMapper {
                 entity.getId(),
                 entity.getSellerId(),
                 entity.getCategoryId(),
-                null,   // inspectorId — JPA 엔티티에 컬럼 추가 후 entity.getInspectorId() 로 교체 (별도 마이그레이션)
+                entity.getInspectorId(),
                 entity.getTitle(),
                 entity.getDescription(),
                 entity.getPrice(),
@@ -64,29 +70,25 @@ public class ProductMapper {
         );
     }
 
-    private List<ProductImageJpaEntity> toImageJpaEntities(List<ProductImage> images) {
-        if (images == null) return new ArrayList<>(); // null 방어 코드
+    // ProductJpaEntity를 받아 팩토리 메서드로 생성 — product NOT NULL 보장
+    private List<ProductImageJpaEntity> toImageJpaEntities(List<ProductImage> images, ProductJpaEntity product) {
+        if (images == null) return new ArrayList<>();
 
         return images.stream()
-                .map(img -> {
-                    // 1. 빌더를 변수로 생성 (상품과 동일한 방식)
-                    var imgBuilder = ProductImageJpaEntity.builder()
-                            .imageUrl(img.getImageUrl())
-                            .sortOrder(img.getSortOrder())
-                            .isThumbnail(img.isThumbnail());
-
-                    // 2. 이미지 ID가 있을 때만(즉, 수정 시에만) ID를 세팅
-                    if (img.getId() != null) {
-                        imgBuilder.id(img.getId());
-                    }
-
-                    return imgBuilder.build();
-                })
+                .map(img -> ProductImageJpaEntity.create(
+                        product,
+                        img.getId(),        // 신규 시 null, 수정 시 기존 id
+                        img.getImageUrl(),
+                        img.getSortOrder(),
+                        img.isThumbnail(),
+                        img.isDeleted(),
+                        img.getDeletedAt()
+                ))
                 .collect(Collectors.toList());
     }
 
     private List<ProductImage> toImageDomains(List<ProductImageJpaEntity> entities) {
-        if (entities == null) return new ArrayList<>(); // null 방어 코드
+        if (entities == null) return new ArrayList<>();
 
         return entities.stream()
                 .map(e -> ProductImage.restore(
@@ -94,7 +96,7 @@ public class ProductMapper {
                         e.getImageUrl(),
                         e.getSortOrder(),
                         e.isThumbnail(),
-                        e.isDeleted(),   
+                        e.isDeleted(),
                         e.getDeletedAt()
                 ))
                 .collect(Collectors.toList());

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,3 +15,23 @@ spring:
 
   main:
     allow-bean-definition-overriding: true
+
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
+internal:
+  secret: ${INTERNAL_SECRET:change-me-in-production}
+
+  # InspectionCompletedListener 등에서 참조하는 토픽명 프로퍼티
+  # config-server가 없는 로컬 환경에서도 기동 가능하도록 기본값 설정
+trusta:
+  messaging:
+    topic:
+      # inspection-service → product-service : 검수 완료 결과 수신
+      inspection-completed: inspection.completed
+      # order-service → product-service : 주문 확정 → SOLD_OUT 전환
+      product-sold-out: order.product.sold-out
+  security:
+    trust-gateway-headers: true


### PR DESCRIPTION


## 🌱 설명

S3 이미지 업로드 기능 개선

## 📌 관련 이슈

close #

## ✅ 주요 변경 사항

- S3Config: ap-northeast-2(서울) → ap-southeast-2(시드니)로 리전 고정
- ProductJpaEntity: @OneToMany @JoinColumn 단방향 구조를 @OneToMany(mappedBy = "product") 양방향으로 변경
- ProductImageJpaEntity: @ManyToOne @JoinColumn(name = "product_id") 추가 product_id FK를 자식 엔티티에서 직접 관리하도록 변경

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [ ] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [ ] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

> 리뷰어가 참고해야 할 내용이 있다면 자유롭게 작성해주세요. (선택)

- 테스트결과
<img width="1497" height="916" alt="스크린샷 2026-05-14 오후 4 49 53" src="https://github.com/user-attachments/assets/9d3d6759-fe77-4065-b5d5-f77f88638d10" />

<img width="1497" height="916" alt="스크린샷 2026-05-14 오후 4 50 01" src="https://github.com/user-attachments/assets/d0163d44-6ed7-4e0e-9bc9-d08a692677a1" />

<img width="1867" height="768" alt="스크린샷 2026-05-14 오후 4 51 34" src="https://github.com/user-attachments/assets/b7df8007-25e5-4a38-bf36-1b3138b7b5ab" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * S3 영역 설정 유효성 검사가 추가되어 구성 누락 시 알림됩니다.
  * 제품과 이미지 간 연관관계가 양방향으로 강화되어 이미지 추가/관리 시 부모 참조가 일관되게 설정됩니다.
  * 제품에 검사자 ID 추적 기능이 추가되었습니다.
  * 제품 이미지의 삭제 플래그 기본값이 명확히 설정되어 소프트 삭제 동작이 안정화되었습니다.
  * 업로드 용량 제한 설정과 내부 시크릿/메시징·보안 관련 설정이 구성에 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trusta-market/product-service/pull/28)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->