### PR TITLE
chore: GKE 배포 설정 추가 (product-service)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,55 @@
+name: Build & Deploy product-service
+
+on:
+  push:
+    branches: [develop, dev]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      IMAGE: asia-northeast3-docker.pkg.dev/trusta-market-id/trusta-registry-services/product-service
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate to GCP (WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/37902116541/locations/global/workloadIdentityPools/trusta-pool-github/providers/trusta-provider-github
+          service_account: trusta-sa-github-deployer@trusta-market-id.iam.gserviceaccount.com
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker auth
+        run: gcloud auth configure-docker asia-northeast3-docker.pkg.dev --quiet
+
+      - name: Build Docker image
+        run: |
+          docker build \
+            --build-arg GPR_USER=${{ secrets.GPR_USER }} \
+            --build-arg GPR_TOKEN=${{ secrets.GPR_TOKEN }} \
+            -t $IMAGE:${{ github.sha }} -t $IMAGE:latest .
+
+      - name: Push image
+        run: docker push --all-tags $IMAGE
+
+      - name: Get GKE credentials
+        uses: google-github-actions/get-gke-credentials@v2
+        with:
+          cluster_name: trusta-cluster
+          location: asia-northeast3-a
+
+      - name: Apply Deployment (with image tag substitution)
+        run: sed "s|PLACEHOLDER|${{ github.sha }}|g" k8s/deployment.yaml | kubectl apply -f -
+
+      - name: Apply Service
+        run: kubectl apply -f k8s/service.yaml
+
+      - name: Wait for rollout
+        run: kubectl rollout status deployment/product-service --timeout=5m

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1.7
+
+FROM gradle:8.10-jdk21-alpine AS builder
+WORKDIR /workspace
+
+ARG GPR_USER
+ARG GPR_TOKEN
+
+COPY settings.gradle build.gradle ./
+COPY gradle ./gradle
+RUN GPR_USER="$GPR_USER" GPR_TOKEN="$GPR_TOKEN" gradle dependencies --no-daemon
+
+COPY src ./src
+
+RUN GPR_USER="$GPR_USER" GPR_TOKEN="$GPR_TOKEN" gradle bootJar --no-daemon \
+ && cp build/libs/*.jar /workspace/app.jar
+
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+
+RUN addgroup -g 1000 -S spring && adduser -u 1000 -S spring -G spring
+
+COPY --from=builder --chown=spring:spring /workspace/app.jar /app/app.jar
+
+USER spring:spring
+
+EXPOSE 8102
+
+ENTRYPOINT ["java", "-XX:MaxRAMPercentage=75.0", "-jar", "/app/app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -31,10 +31,11 @@ repositories {
 }
 
 dependencies {
-	implementation 'com.trustamarket:common:0.0.1-SNAPSHOT'
+	implementation 'com.trustamarket:common:0.1.0-SNAPSHOT'
 
 	// spring
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: product-service
+  labels:
+    app: product-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: product-service
+  template:
+    metadata:
+      labels:
+        app: product-service
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: product-service
+          image: asia-northeast3-docker.pkg.dev/trusta-market-id/trusta-registry-services/product-service:PLACEHOLDER
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - containerPort: 8102
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "k8s"
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: domain-postgres-secrets
+                  key: DB_USERNAME
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: domain-postgres-secrets
+                  key: DB_PASSWORD
+            # AWS / ES env 는 K8s 에 없음. autoconfig exclude 로 회피 (application-k8s.yml 참조).
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 1000m
+              memory: 2Gi
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8102
+            failureThreshold: 30
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8102
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8102
+            periodSeconds: 5

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: product-service
+  labels:
+    app: product-service
+spec:
+  type: ClusterIP
+  selector:
+    app: product-service
+  ports:
+    - port: 80
+      targetPort: 8102
+      protocol: TCP

--- a/src/main/resources/application-k8s.yml
+++ b/src/main/resources/application-k8s.yml
@@ -1,0 +1,41 @@
+# K8s 환경 전용 override (SPRING_PROFILES_ACTIVE=k8s 일 때만 로드).
+
+server:
+  port: 8102
+
+spring:
+  config:
+    import: "optional:configserver:http://config-server"
+  cloud:
+    config:
+      uri: http://config-server
+      label: develop
+      fail-fast: false
+  datasource:
+    url: jdbc:postgresql://postgres:5432/trusta_market
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        default_schema: p_product
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+    open-in-view: false
+  # Elasticsearch / AWS S3 는 K8s 환경에서 미사용 — autoconfig 비활성 (startup 시 connection 실패 방지).
+  # 후속에 실제 ES / S3 셋업 시 이 exclude 제거 + 해당 URL 환경변수로 주입.
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchRestClientAutoConfiguration
+      - org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://eureka-server/eureka/
+    register-with-eureka: true
+    fetch-registry: true
+  instance:
+    prefer-ip-address: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,3 +15,13 @@ spring:
 
   main:
     allow-bean-definition-overriding: true
+
+management:
+  endpoint:
+    health:
+      probes:
+        enabled: true
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus


### PR DESCRIPTION
## 🌱 설명

product-service GKE 배포 셋업. 도메인 공유 PG + config-server + Eureka 와 연동.
schema `p_product` 사용. ES / AWS S3 는 K8s 환경에 없어 autoconfig 비활성.

## ✅ 주요 변경 사항

- `application.yaml` — management 블록 추가 (health probes + prometheus). 기존 `allow-bean-definition-overriding: true` 유지
- `application-k8s.yml` (신규) — Spring Profile k8s: server.port 8102, config-server URI, datasource (placeholder), jpa(schema p_product), eureka. ES / Elasticsearch autoconfig exclude
- `build.gradle` — `micrometer-registry-prometheus` 추가
- `Dockerfile` — multi-stage + non-root spring UID 1000, `ARG GPR_USER/GPR_TOKEN`
- `k8s/deployment.yaml` — replicas 1, env SPRING_PROFILES_ACTIVE=k8s + DB Secret, securityContext, probes
- `k8s/service.yaml` — ClusterIP port 80 → targetPort 8102
- `.github/workflows/deploy.yml` — develop / dev push 모두 트리거 (default branch 가 아직 dev)

## 🔧 머지 전 필수

- Postgres 에 schema `p_product` 미리 생성:
  ```bash
  kubectl exec deployment/postgres -- psql -U trusta_admin -d trusta_market -c "CREATE SCHEMA IF NOT EXISTS p_product"
  ```
- Secret `domain-postgres-secrets` 이미 존재 (이전 작업)
- repo secret `GPR_USER`, `GPR_TOKEN` 이미 등록

## 🧪 검증

```bash
kubectl get pods -l app=product-service
kubectl logs deployment/product-service --tail=60
```

## 📚 후속

- ES / S3 K8s 도입 시점에 application-k8s.yml 의 autoconfig exclude 제거 + URL/Credential 환경변수 주입
- Kafka 셋업 후 KAFKA_BOOTSTRAP env 추가
- default branch `dev` → `develop` 통일 (별도 작업)
- 환경 설정 config-repo 통합 (refactor issue 참조)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 애플리케이션 헬스 체크 및 실시간 상태 모니터링 기능 추가
  * Prometheus 기반 메트릭 수집 및 모니터링 지원

* **Chores**
  * 쿠버네티스 클라우드 배포 인프라 구성
  * 자동 배포 파이프라인 설정
  * 의존성 버전 업데이트

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trusta-market/product-service/pull/29)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->