### PR TITLE
expose prometheus endpoint (product 만 누락)

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -35,3 +35,14 @@ trusta:
       product-sold-out: order.product.sold-out
   security:
     trust-gateway-headers: true
+
+# 다른 service 와 동일 패턴 — k8s liveness/readiness probe + prometheus scrape.
+management:
+  endpoint:
+    health:
+      probes:
+        enabled: true
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus


### PR DESCRIPTION
다른 9 service 는 노출, product 만 빠져있어서 metric scrape 실패. 동일 패턴으로 통일.