### PR TITLE
product pool 32 + memory 2.5Gi

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -51,15 +51,15 @@ spec:
                   key: DB_PASSWORD
             # AWS / ES env 는 K8s 에 없음. autoconfig exclude 로 회피 (application-k8s.yml 참조).
           # request 는 실 사용량 기반 (CPU ~25m, memory ~400Mi, burst 여유 포함).
-          # limit 은 thread 800 stack (~800MB) + heap (limit*25%=500MB) + 기타 = ~1.5GB 안에 맞춤.
-          # request 줄임 → 노드당 pod 수 증가 → HPA scale 자리 확보 (e2-medium 4Gi 노드 기준 3 pod/노드).
+          # limit memory 2Gi → 2.5Gi — pool 32 connection state + 3차 부하 시 restart 2회 (burst OOM 의심) 방지.
+          # thread 800 stack 800MB + heap (limit*25%=625MB) + pool 32 connection state + 기타 = ~1.8GB → 2.5Gi 안 여유.
           resources:
             requests:
               cpu: 100m
               memory: 800Mi
             limits:
               cpu: 1500m
-              memory: 2Gi
+              memory: 2500Mi
           # startupProbe — /actuator/health/liveness (application 자체만).
           # /actuator/health (전체 합산) 는 외부 의존성 (Kafka/ES 등) 한 군데 DOWN 만 돼도 503 → kill.
           startupProbe:

--- a/src/main/resources/application-k8s.yml
+++ b/src/main/resources/application-k8s.yml
@@ -22,10 +22,12 @@ spring:
     url: jdbc:postgresql://postgres:5432/trusta_market
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
-    # HikariCP pool — default 10 이 thread 800 대비 너무 작아서 thread 가 pool 대기.
-    # postgres max_connections=700 안에서 7 DB service × pool 18 × HPA max 5 = 630 (안전선).
+    # HikariCP pool — 3차 부하 결과로 product 만 pending 332 도달 (다른 service pending 0).
+    # 다른 service 그대로 두고 product 만 극단. DB 한계 안 자리:
+    # 6 × 18 × 5 = 540 → 남은 160 / product 5 pod = pool 32 가 max.
+    # 합 = 540 + 5 × 32 = 700 / 700 정확.
     hikari:
-      maximum-pool-size: 18
+      maximum-pool-size: 32
   jpa:
     hibernate:
       ddl-auto: validate


### PR DESCRIPTION
3차 부하의 첫 병목 (product DB pool full) 해소. 다른 service 그대로, product 만 변경.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Kubernetes 환경의 메모리 할당량을 조정하여 시스템 안정성을 개선했습니다.
  * 데이터베이스 커넥션 풀 설정을 최적화하여 동시 처리 성능을 강화했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trusta-market/product-service/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->