### PR TITLE
datasource url DB_HOST env 추가 (Cloud SQL 마이그)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -49,6 +49,12 @@ spec:
                 secretKeyRef:
                   name: domain-postgres-secrets
                   key: DB_PASSWORD
+            # DB_HOST — Cloud SQL Private IP (Secret 에서 주입). application-k8s.yml 의 ${DB_HOST:postgres} 와 대응.
+            - name: DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: domain-postgres-secrets
+                  key: DB_HOST
             # AWS / ES env 는 K8s 에 없음. autoconfig exclude 로 회피 (application-k8s.yml 참조).
           # request 는 실 사용량 기반 (CPU ~25m, memory ~400Mi, burst 여유 포함).
           # limit memory 2Gi → 2.5Gi — pool 32 connection state + 3차 부하 시 restart 2회 (burst OOM 의심) 방지.

--- a/src/main/resources/application-k8s.yml
+++ b/src/main/resources/application-k8s.yml
@@ -19,7 +19,9 @@ spring:
       label: develop
       fail-fast: false
   datasource:
-    url: jdbc:postgresql://postgres:5432/trusta_market
+    # DB_HOST env 로 endpoint 주입 (Secret domain-postgres-secrets). default = postgres (in-cluster fallback).
+    # Cloud SQL 마이그 시 Secret 의 DB_HOST 만 변경 → 코드 변경 X.
+    url: jdbc:postgresql://${DB_HOST:postgres}:5432/trusta_market
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     # HikariCP pool — 3차 부하 결과로 product 만 pending 332 도달 (다른 service pending 0).


### PR DESCRIPTION
domain-postgres-secrets 의 DB_HOST 로 endpoint 주입. Cloud SQL Private IP 가 manifest/코드에 노출 X. default = postgres (in-cluster fallback).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- 데이터베이스 호스트 설정이 환경 변수 기반으로 변경되었습니다. 이를 통해 배포 환경에 따라 데이터베이스 호스트를 더 유연하게 관리할 수 있으며, 기본값이 자동으로 적용되어 기존 배포 환경과의 호환성이 유지됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trusta-market/product-service/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->