### PR TITLE
pool 6차 셋 복귀 (18/32)

### DIFF
--- a/src/main/resources/application-k8s.yml
+++ b/src/main/resources/application-k8s.yml
@@ -24,12 +24,11 @@ spring:
     url: jdbc:postgresql://${DB_HOST:postgres}:5432/trusta_market
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
-    # HikariCP pool — 3차 부하 결과로 product 만 pending 332 도달 (다른 service pending 0).
-    # 다른 service 그대로 두고 product 만 극단. DB 한계 안 자리:
-    # 6 × 18 × 5 = 540 → 남은 160 / product 5 pod = pool 32 가 max.
-    # 합 = 540 + 5 × 32 = 700 / 700 정확.
+    # HikariCP pool — Cloud SQL max_connections=2500 안에서 진짜 짜내기.
+    # product = 다른 service 의 2배 (50% read 비중). 다른 6 service = 60.
+    # 합 = 6 × 60 × 5 + 5 × 120 = 1800 + 600 = 2400 / 2500 ✓ (여유 100).
     hikari:
-      maximum-pool-size: 32
+      maximum-pool-size: 120
   jpa:
     hibernate:
       ddl-auto: validate

--- a/src/main/resources/application-k8s.yml
+++ b/src/main/resources/application-k8s.yml
@@ -24,11 +24,11 @@ spring:
     url: jdbc:postgresql://${DB_HOST:postgres}:5432/trusta_market
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
-    # HikariCP pool — Cloud SQL max_connections=2500 안에서 진짜 짜내기.
-    # product = 다른 service 의 2배 (50% read 비중). 다른 6 service = 60.
-    # 합 = 6 × 60 × 5 + 5 × 120 = 1800 + 600 = 2400 / 2500 ✓ (여유 100).
+    # HikariCP pool — 8차 부하 결과로 pool 60/120 은 GC pause + tail latency 폭증 (DB 한가 + connection state heap 점유).
+    # 6차 셋 (pool 18/32 + cache) 가 진짜 sweet spot — 그 셋으로 복귀.
+    # product 만 cache 의 lookup 동시성 + miss 시 query 안전선으로 32 유지.
     hikari:
-      maximum-pool-size: 120
+      maximum-pool-size: 32
   jpa:
     hibernate:
       ddl-auto: validate


### PR DESCRIPTION
8차 결과로 pool 60/120 = GC pause + tail latency 38s + 1.44% fail. 6차 sweet spot 복귀.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Kubernetes 환경 설정 문서를 업데이트했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trusta-market/product-service/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->