### PR TITLE
[refactor] : void 반환 메서드를 CommonResponse<Void>로 변경

### DIFF
--- a/src/main/java/com/trustamarket/productservice/presentation/controller/CategoryController.java
+++ b/src/main/java/com/trustamarket/productservice/presentation/controller/CategoryController.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -73,8 +74,8 @@ public class CategoryController {
 
     // 카테고리 삭제 (관리자용)
     @DeleteMapping("/{categoryId}")
-    public CommonResponse<Void> delete(@PathVariable UUID categoryId) {
+    public ResponseEntity<Void> delete(@PathVariable UUID categoryId) {
         categoryService.delete(categoryId);
-        return CommonResponse.of(HttpStatus.OK.value(), null);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/trustamarket/productservice/presentation/controller/CategoryController.java
+++ b/src/main/java/com/trustamarket/productservice/presentation/controller/CategoryController.java
@@ -1,5 +1,6 @@
 package com.trustamarket.productservice.presentation.controller;
 
+import com.trustamarket.common.response.CommonResponse;
 import com.trustamarket.productservice.application.CategoryService;
 import com.trustamarket.productservice.domain.category.Category;
 import com.trustamarket.productservice.domain.category.InspectionPolicy;
@@ -72,8 +73,8 @@ public class CategoryController {
 
     // 카테고리 삭제 (관리자용)
     @DeleteMapping("/{categoryId}")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(@PathVariable UUID categoryId) {
+    public CommonResponse<Void> delete(@PathVariable UUID categoryId) {
         categoryService.delete(categoryId);
+        return CommonResponse.of(HttpStatus.OK.value(), null);
     }
 }

--- a/src/main/java/com/trustamarket/productservice/presentation/controller/ProductController.java
+++ b/src/main/java/com/trustamarket/productservice/presentation/controller/ProductController.java
@@ -1,5 +1,6 @@
 package com.trustamarket.productservice.presentation.controller;
 
+import com.trustamarket.common.response.CommonResponse;
 import com.trustamarket.common.util.SecurityUtil;
 import com.trustamarket.productservice.application.ProductCommandService;
 import com.trustamarket.productservice.application.ProductQueryService;
@@ -31,13 +32,13 @@ public class ProductController {
     private final ProductQueryService productQueryService;
 
     @PostMapping("/{productId}/inspection")
-    @ResponseStatus(HttpStatus.OK)
-    public void requestInspection(
+    public CommonResponse<Void> requestInspection(
             @PathVariable UUID productId,
             @Valid @RequestBody InspectionRequestDto request
     ) {
         UUID sellerId = SecurityUtil.getCurrentUserIdOrThrow();
         productCommandService.requestInspection(productId, sellerId, request.getCenterId());
+        return CommonResponse.of(HttpStatus.OK.value(), null);
     }
 
     @PostMapping
@@ -106,10 +107,10 @@ public class ProductController {
     }
 
     @DeleteMapping("/{productId}")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(@PathVariable UUID productId) {
+    public CommonResponse<Void> delete(@PathVariable UUID productId) {
         UUID sellerId = SecurityUtil.getCurrentUserIdOrThrow();
         productCommandService.deleteProduct(productId, sellerId);
+        return CommonResponse.of(HttpStatus.OK.value(), null);
     }
 
     @PatchMapping("/{productId}/status")

--- a/src/main/java/com/trustamarket/productservice/presentation/controller/ProductImageController.java
+++ b/src/main/java/com/trustamarket/productservice/presentation/controller/ProductImageController.java
@@ -1,5 +1,6 @@
 package com.trustamarket.productservice.presentation.controller;
 
+import com.trustamarket.common.response.CommonResponse;
 import com.trustamarket.common.util.SecurityUtil;
 import com.trustamarket.productservice.application.ProductImageAppService;
 import com.trustamarket.productservice.domain.product.Product;
@@ -37,13 +38,13 @@ public class ProductImageController {
     }
 
     @DeleteMapping("/{imageId}")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void removeImage(
+    public CommonResponse<Void> removeImage(
             @PathVariable UUID productId,
             @PathVariable UUID imageId
     ) {
         UUID sellerId = SecurityUtil.getCurrentUserIdOrThrow();
         productImageAppService.removeImage(productId, sellerId, imageId);
+        return CommonResponse.of(HttpStatus.OK.value(), null);
     }
 
     @PatchMapping("/{imageId}/thumbnail")


### PR DESCRIPTION
## 🌱 설명

void 반환 메서드를 CommonResponse<Void>로 변경
## 📌 관련 이슈

close #49

## ✅ 주요 변경 사항

- ProductController: requestInspection, delete
- ProductImageController: removeImage
- CategoryController: delete

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [ ] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [ ] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

> 리뷰어가 참고해야 할 내용이 있다면 자유롭게 작성해주세요. (선택)

- 예) 라이브러리 버전을 올리면서 설정 방식이 변경되었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선사항**
  * 카테고리 삭제, 제품 삭제, 제품 이미지 삭제, 제품 검수 요청 API의 응답 형식을 표준화했습니다.
  * 관련 엔드포인트들이 일관된 응답 구조(CommonResponse/ResponseEntity 기반)와 명확한 HTTP 상태로 클라이언트에 반환됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->