### PR TITLE
[Refactor] : 72 separate domain from jpa

### DIFF
--- a/src/main/java/com/trustamarket/productservice/domain/product/Product.java
+++ b/src/main/java/com/trustamarket/productservice/domain/product/Product.java
@@ -3,71 +3,43 @@ package com.trustamarket.productservice.domain.product;
 import com.trustamarket.productservice.application.exception.ImageNotFoundException;
 import com.trustamarket.productservice.application.exception.InvalidInspectionStatusException;
 import com.trustamarket.productservice.application.exception.errorcode.ProductErrorCode;
-import jakarta.persistence.*;
 import lombok.AccessLevel;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.Instant;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
 
-@Entity
 @Getter
-@Table(name = "p_products")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class Product {
 
     private static final int MAX_IMAGE_COUNT = 10;
     private static final int MAX_TITLE_LENGTH = 100;
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    @EqualsAndHashCode.Include
     private UUID productId;
-
-    @Column(nullable = false)
     private UUID sellerId;
-
-    @Column(nullable = false)
     private UUID categoryId;
-
     private UUID inspectorId;
-
-    @Column(nullable = false, length = MAX_TITLE_LENGTH)
     private String title;
-
-    @Column(columnDefinition = "TEXT")
     private String description;
-
-    @Column(nullable = false)
     private Long price;
 
     // inspection-service가 제안한 가격. PRICE_SUGGESTED 상태일 때만 유효하며, 판매자가 수락하면 price를 이 값으로 교체한다.
-    @Column
     private Long suggestedPrice;
 
-    @Enumerated(EnumType.STRING)
     private ProductGrade grade;
-
-    @Enumerated(EnumType.STRING)
     private ProductStatus status;
-
-    @Enumerated(EnumType.STRING)
     private InspectionStatus inspectionStatus;
 
-    // orphanRemoval=true — update() 의 images.clear() 가 DB row 도 같이 삭제하도록 (orphan row 방지)
-    // @OrderBy — sortOrder 변경 후 응답 순서 안정화 (reorder 후 reload 없이도 정렬됨)
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
-    @OrderBy("sortOrder ASC")
-    @JoinColumn(name = "product_id")
     private List<ProductImage> images;
 
-    @Column(nullable = false)
     private boolean deleted = false;
-
-    @Column
     private Instant deletedAt;
 
     private Instant createdAt;
@@ -164,7 +136,7 @@ public class Product {
         }
 
         if (imageUrls != null) {
-            this.images.clear(); // 기존 이미지 초기화 (orphanRemoval=true 설정 시 DB에서도 삭제됨)
+            this.images.clear(); // 기존 이미지 초기화 (도메인 컬렉션에서 제거; JPA 측은 ProductJpaEntity 의 orphanRemoval 이 담당)
             for (int i = 0; i < imageUrls.size(); i++) {
                 this.addImage(ProductImage.create(this, imageUrls.get(i), i, i == 0));
             }
@@ -220,7 +192,7 @@ public class Product {
         onUpdate();
     }
 
-// 검수 대상 여부 — 카테고리별 기준 금액과 비교
+    // 검수 대상 여부 — 카테고리별 기준 금액과 비교
     public boolean requiresInspection(int highValueThreshold) {
         return this.price >= highValueThreshold;
     }
@@ -318,7 +290,7 @@ public class Product {
                 .findFirst()
                 .orElseThrow(() -> new ImageNotFoundException(ProductErrorCode.IMAGE_NOT_FOUND));
 
-        targetImage.delete(); // ProductImage 엔티티에 추가한 delete() 호출
+        targetImage.delete();
 
         // 2. 만약 삭제된 이미지가 대표 이미지(Thumbnail)였다면 다른 이미지를 재설정
         if (targetImage.isThumbnail()) {

--- a/src/main/java/com/trustamarket/productservice/domain/product/ProductImage.java
+++ b/src/main/java/com/trustamarket/productservice/domain/product/ProductImage.java
@@ -79,7 +79,9 @@ public class ProductImage {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof ProductImage that)) return false;
+        if (o == null || getClass() != o.getClass()) return false;
+        ProductImage that = (ProductImage) o;
+        // imageId 가 null 인 transient 상태에서는 참조 동일성 (this == o) 만 인정
         return imageId != null && imageId.equals(that.imageId);
     }
 

--- a/src/main/java/com/trustamarket/productservice/domain/product/ProductImage.java
+++ b/src/main/java/com/trustamarket/productservice/domain/product/ProductImage.java
@@ -2,7 +2,6 @@ package com.trustamarket.productservice.domain.product;
 
 import com.trustamarket.productservice.application.exception.InvalidImageUrlException;
 import com.trustamarket.productservice.application.exception.errorcode.ProductErrorCode;
-import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -11,17 +10,12 @@ import lombok.NoArgsConstructor;
 import java.time.Instant;
 import java.util.UUID;
 
-@Entity
-@Table(name = "p_product_images")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EqualsAndHashCode(of = "imageId")
 public class ProductImage {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
     private UUID imageId;
-    
     private String imageUrl;
     private int sortOrder;
     private boolean isThumbnail;

--- a/src/main/java/com/trustamarket/productservice/domain/product/ProductImage.java
+++ b/src/main/java/com/trustamarket/productservice/domain/product/ProductImage.java
@@ -3,7 +3,6 @@ package com.trustamarket.productservice.domain.product;
 import com.trustamarket.productservice.application.exception.InvalidImageUrlException;
 import com.trustamarket.productservice.application.exception.errorcode.ProductErrorCode;
 import lombok.AccessLevel;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,7 +11,6 @@ import java.util.UUID;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EqualsAndHashCode(of = "imageId")
 public class ProductImage {
 
     private UUID imageId;
@@ -76,5 +74,17 @@ public class ProductImage {
         if (imageUrl == null || imageUrl.isBlank()) {
             throw new InvalidImageUrlException(ProductErrorCode.INVALID_IMAGE_URL);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ProductImage that)) return false;
+        return imageId != null && imageId.equals(that.imageId);
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
     }
 }

--- a/src/main/java/com/trustamarket/productservice/infrastructure/config/JpaConfig.java
+++ b/src/main/java/com/trustamarket/productservice/infrastructure/config/JpaConfig.java
@@ -3,13 +3,17 @@ package com.trustamarket.productservice.infrastructure.config;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @Configuration
 @RequiredArgsConstructor
 @EnableJpaAuditing
+@EntityScan(basePackages = "com.trustamarket.productservice.infrastructure.persistence.entity")
+@EnableJpaRepositories(basePackages = "com.trustamarket.productservice.infrastructure.persistence")
 public class JpaConfig {
 
     private final EntityManager entityManager;

--- a/src/test/java/com/trustamarket/productservice/application/ProductCommandServiceTest.java
+++ b/src/test/java/com/trustamarket/productservice/application/ProductCommandServiceTest.java
@@ -141,30 +141,35 @@ class ProductCommandServiceTest {
     @DisplayName("price null → InvalidPriceException (ErrorCode: INVALID_PRICE)")
     void priceNull_throws() {
         UUID sellerId = UUID.randomUUID();
-        Category cat = category("패션", 200_000);
-        when(categoryRepository.findById(cat.getCategoryId())).thenReturn(Optional.of(cat));
+        UUID categoryId = UUID.randomUUID();
+        // validatePrice 가 카테고리 조회 전에 실행되므로 categoryRepository stub 불필요
 
         assertThatThrownBy(() ->
-                service.create(sellerId, "title", "desc", null, cat.getCategoryId(), null)
+                service.create(sellerId, "title", "desc", null, categoryId, null)
         )
                 .isInstanceOf(ProductException.class)
                 .extracting(e -> ((ProductException) e).getErrorCode())
                 .isEqualTo(ProductErrorCode.INVALID_PRICE);
+
+        // 카테고리 조회가 호출되지 않았음을 명시적으로 검증 (회귀 방지)
+        verify(categoryRepository, never()).findById(any());
     }
 
     @Test
     @DisplayName("price 음수 → InvalidPriceException (ErrorCode: INVALID_PRICE)")
     void priceNegative_throws() {
         UUID sellerId = UUID.randomUUID();
-        Category cat = category("패션", 200_000);
-        when(categoryRepository.findById(cat.getCategoryId())).thenReturn(Optional.of(cat));
+        UUID categoryId = UUID.randomUUID();
+        // validatePrice 가 카테고리 조회 전에 실행되므로 categoryRepository stub 불필요
 
         assertThatThrownBy(() ->
-                service.create(sellerId, "title", "desc", -1L, cat.getCategoryId(), null)
+                service.create(sellerId, "title", "desc", -1L, categoryId, null)
         )
                 .isInstanceOf(ProductException.class)
                 .extracting(e -> ((ProductException) e).getErrorCode())
                 .isEqualTo(ProductErrorCode.INVALID_PRICE);
+
+        verify(categoryRepository, never()).findById(any());
     }
 
     @Test


### PR DESCRIPTION
## 🌱 설명

문제:
`domain/product/Product.java`, `domain/product/ProductImage.java` 에 JPA 어노테이션(`@Entity`, `@Table`, `@Id` 등)이 남아 있어,
infrastructure 패키지의 `ProductJpaEntity` / `ProductImageJpaEntity` 와 함께 동일 테이블에 두 엔티티가 매핑되는 문제가 있었습니다.

`ProductServiceApplication`에 `@EntityScan` 명시가 없어 기본 패키지 스캔 범위에 도메인과 인프라가 모두 포함되어 다음과 같은 부작용이 발생합니다.

- Hibernate 메타데이터 캐시가 동일 테이블에 대해 두 번 등록됨
- L1/L2 캐시가 같은 row 에 대해 서로 다른 인스턴스를 보유 → 일관성 혼란 여지
- 부팅 시간 증가
- Clean architecture 의도와 정면 충돌

## 📌 관련 이슈

close #75

## ✅ 주요 변경 사항

- ProductImage 에서 JPA 어노테이션 제거
- Product 에서 JPA 어노테이션 제거
- JPA EntityScan / Repository 스캔 범위 명시

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [ ] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [ ] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [ ] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

> 리뷰어가 참고해야 할 내용이 있다면 자유롭게 작성해주세요. (선택)

- 예) 라이브러리 버전을 올리면서 설정 방식이 변경되었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 상품 가격이 잘못된 경우(누락/음수) 예외가 더 일관되게 발생하며, 불필요한 카테고리 조회 및 처리 동작을 하지 않도록 수정했습니다.
* **Refactor**
  * 상품·상품 이미지 도메인 모델을 ORM 의존 요소 없이 단순화하고, 생성/수정/삭제 시점 정보를 도메인에서 추적하도록 변경했습니다.
  * 이미지 식별자 기반의 동일성/해시 동작을 명확히 했습니다.
* **Chores**
  * JPA 엔티티/리포지토리 스캔 범위를 명시적으로 정리했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->