### PR TITLE
[refactor] : Outbox 폴링 SKIP LOCKED 적용으로 멀티 파드 안전성 확보

### DIFF
--- a/src/main/java/com/trustamarket/productservice/infrastructure/kafka/OutboxEventClaimer.java
+++ b/src/main/java/com/trustamarket/productservice/infrastructure/kafka/OutboxEventClaimer.java
@@ -1,0 +1,26 @@
+package com.trustamarket.productservice.infrastructure.kafka;
+
+import com.trustamarket.productservice.infrastructure.persistence.OutboxEventJpaRepository;
+import com.trustamarket.productservice.infrastructure.persistence.entity.OutboxEventJpaEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class OutboxEventClaimer {
+
+    private final OutboxEventJpaRepository outboxEventRepository;
+
+    // 짧은 TX: SKIP LOCKED로 락 획득 → claimed = true 세팅 → 즉시 커밋
+    // 커밋 후 락 해제되지만 claimed = false 조건 덕분에 다른 파드가 건너뜀
+    @Transactional
+    public List<OutboxEventJpaEntity> claimBatch(int batchSize) {
+        List<OutboxEventJpaEntity> events = outboxEventRepository.lockNextBatch(batchSize);
+        events.forEach(OutboxEventJpaEntity::markClaimed);
+        outboxEventRepository.saveAll(events);
+        return events;
+    }
+}

--- a/src/main/java/com/trustamarket/productservice/infrastructure/kafka/OutboxEventProducer.java
+++ b/src/main/java/com/trustamarket/productservice/infrastructure/kafka/OutboxEventProducer.java
@@ -5,9 +5,9 @@ import com.trustamarket.productservice.infrastructure.persistence.entity.OutboxE
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -26,10 +26,9 @@ public class OutboxEventProducer {
     private int batchSize;
 
     @Scheduled(fixedDelayString = "${trusta.outbox.poll-interval-ms:1000}")
+    @Transactional
     public void producePendingEvents() {
-        List<OutboxEventJpaEntity> events =
-                outboxEventRepository.findByPublishedFalseAndFailedFalseOrderByCreatedAtAsc(
-                        PageRequest.of(0, batchSize));
+        List<OutboxEventJpaEntity> events = outboxEventRepository.lockNextBatch(batchSize);
 
         for (OutboxEventJpaEntity event : events) {
             boolean shouldContinue = outboxEventProcessor.process(event, maxRetry);

--- a/src/main/java/com/trustamarket/productservice/infrastructure/kafka/OutboxEventProducer.java
+++ b/src/main/java/com/trustamarket/productservice/infrastructure/kafka/OutboxEventProducer.java
@@ -1,13 +1,11 @@
 package com.trustamarket.productservice.infrastructure.kafka;
 
-import com.trustamarket.productservice.infrastructure.persistence.OutboxEventJpaRepository;
 import com.trustamarket.productservice.infrastructure.persistence.entity.OutboxEventJpaEntity;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -16,7 +14,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class OutboxEventProducer {
 
-    private final OutboxEventJpaRepository outboxEventRepository;
+    private final OutboxEventClaimer outboxEventClaimer;
     private final OutboxEventProcessor outboxEventProcessor;
 
     @Value("${trusta.outbox.max-retry:5}")
@@ -25,10 +23,10 @@ public class OutboxEventProducer {
     @Value("${trusta.outbox.batch-size:500}")
     private int batchSize;
 
+    // ✅ @Transactional 제거 — 락 획득/처리 트랜잭션 분리
     @Scheduled(fixedDelayString = "${trusta.outbox.poll-interval-ms:1000}")
-    @Transactional
     public void producePendingEvents() {
-        List<OutboxEventJpaEntity> events = outboxEventRepository.lockNextBatch(batchSize);
+        List<OutboxEventJpaEntity> events = outboxEventClaimer.claimBatch(batchSize);
 
         for (OutboxEventJpaEntity event : events) {
             boolean shouldContinue = outboxEventProcessor.process(event, maxRetry);

--- a/src/main/java/com/trustamarket/productservice/infrastructure/persistence/OutboxEventJpaRepository.java
+++ b/src/main/java/com/trustamarket/productservice/infrastructure/persistence/OutboxEventJpaRepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
@@ -15,13 +14,12 @@ public interface OutboxEventJpaRepository extends JpaRepository<OutboxEventJpaEn
 
     @Query(value = """
         SELECT * FROM p_outbox_events
-        WHERE published = false AND failed = false
+        WHERE published = false AND failed = false AND claimed = false
         ORDER BY created_at
         LIMIT :batchSize
         FOR UPDATE SKIP LOCKED
     """, nativeQuery = true)
     List<OutboxEventJpaEntity> lockNextBatch(@Param("batchSize") int batchSize);
-
 
     @Modifying
     @Query("DELETE FROM OutboxEventJpaEntity e WHERE e.published = true AND e.publishedAt < :cutoff")

--- a/src/main/java/com/trustamarket/productservice/infrastructure/persistence/OutboxEventJpaRepository.java
+++ b/src/main/java/com/trustamarket/productservice/infrastructure/persistence/OutboxEventJpaRepository.java
@@ -1,10 +1,11 @@
 package com.trustamarket.productservice.infrastructure.persistence;
 
 import com.trustamarket.productservice.infrastructure.persistence.entity.OutboxEventJpaEntity;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 
 import java.time.Instant;
 import java.util.List;
@@ -12,7 +13,15 @@ import java.util.UUID;
 
 public interface OutboxEventJpaRepository extends JpaRepository<OutboxEventJpaEntity, UUID> {
 
-    List<OutboxEventJpaEntity> findByPublishedFalseAndFailedFalseOrderByCreatedAtAsc(Pageable pageable);
+    @Query(value = """
+        SELECT * FROM p_outbox_events
+        WHERE published = false AND failed = false
+        ORDER BY created_at
+        LIMIT :batchSize
+        FOR UPDATE SKIP LOCKED
+    """, nativeQuery = true)
+    List<OutboxEventJpaEntity> lockNextBatch(@Param("batchSize") int batchSize);
+
 
     @Modifying
     @Query("DELETE FROM OutboxEventJpaEntity e WHERE e.published = true AND e.publishedAt < :cutoff")

--- a/src/main/java/com/trustamarket/productservice/infrastructure/persistence/entity/OutboxEventJpaEntity.java
+++ b/src/main/java/com/trustamarket/productservice/infrastructure/persistence/entity/OutboxEventJpaEntity.java
@@ -35,13 +35,16 @@ public class OutboxEventJpaEntity {
     private Instant publishedAt;
 
     @Column(nullable = false)
-    private int retryCount = 0;         // 발행 시도 실패 횟수
+    private int retryCount = 0;
 
     @Column
-    private Instant lastFailedAt;       // 마지막 실패 시각 (모니터링용)
+    private Instant lastFailedAt;
 
     @Column(nullable = false)
     private boolean failed = false;
+
+    @Column(nullable = false)
+    private boolean claimed = false;
 
     @Builder
     public OutboxEventJpaEntity(String topic, String payload) {
@@ -55,14 +58,16 @@ public class OutboxEventJpaEntity {
         this.publishedAt = Instant.now();
     }
 
-    // 실패 횟수 증가
     public void incrementRetryCount() {
         this.retryCount++;
         this.lastFailedAt = Instant.now();
     }
 
-    //  최대 재시도 초과 시 격리
     public void markFailed() {
         this.failed = true;
+    }
+
+    public void markClaimed() {
+        this.claimed = true;
     }
 }

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -26,3 +26,6 @@ databaseChangeLog:
   - include:
       file: sql/V009__add_composite_partial_indexes.sql
       relativeToChangelogFile: true
+  - include:
+      file: sql/V010__add_claimed_to_outbox_events.sql
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/sql/V010__add_claimed_to_outbox_events.sql
+++ b/src/main/resources/db/changelog/sql/V010__add_claimed_to_outbox_events.sql
@@ -1,0 +1,7 @@
+-- Outbox 중복 처리 방지를 위한 claimed 컬럼 추가
+ALTER TABLE p_outbox_events ADD COLUMN claimed boolean NOT NULL DEFAULT false;
+
+-- claimed = false 조건 포함 부분 인덱스 (폴링 쿼리 성능)
+CREATE INDEX IF NOT EXISTS idx_outbox_pending
+    ON p_outbox_events (created_at)
+    WHERE published = false AND failed = false AND claimed = false;


### PR DESCRIPTION
## 🌱 설명

- Outbox 폴링 SKIP LOCKED 적용으로 멀티 파드 안전성 확보

## 📌 관련 이슈

close #79 

## ✅ 주요 변경 사항

- OutboxEventJpaRepository: lockNextBatch() 네이티브 쿼리 추가
- OutboxEventProducer: @Transactional 추가로 락 유지 보장, lockNextBatch() 호출로 교체

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [ ] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [ ] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [ ] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

> 리뷰어가 참고해야 할 내용이 있다면 자유롭게 작성해주세요. (선택)

- 예) 라이브러리 버전을 올리면서 설정 방식이 변경되었습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 대기 중인 이벤트를 한 번에 안전하게 가져오는 방식이 개선되어, 처리 중 중복 실행 가능성을 줄였습니다.
  * 이벤트 처리 작업이 트랜잭션 안에서 실행되도록 변경되었습니다.

* **Bug Fixes**
  * 이벤트 배치 조회 방식이 단순 목록 조회에서 락을 선점하는 방식으로 바뀌어, 동시에 여러 작업이 돌 때의 충돌을 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->